### PR TITLE
Add namespace value flag to syntax explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ function kubectl() { echo "+ kubectl $@"; command kubectl $@; }
   * **`sl`**: `--show-labels`
   * **`w`**=`-w/--watch`
 * value flags (should be at the end):
+  * **`n`**=`-n/--namespace`
   * **`f`**=`-f/--filename`
   * **`l`**=`-l/--selector`
   


### PR DESCRIPTION
This PR adds an explanation of the `n` value flag to the README.